### PR TITLE
Updated interview preparation link because an old link now returns 404

### DIFF
--- a/hack-evenings/README.md
+++ b/hack-evenings/README.md
@@ -6,7 +6,7 @@ Learning Resources
 
   * Constant challenges in several languages: https://www.codingame.com/start
   * Exercism: and yet more coding challenges in several language: http://www.exercism.io/
-  * Cracking the coding interview at hackerrank: https://www.hackerrank.com/domains/tutorials/cracking-the-coding-interview
+  * Cracking the coding interview at hackerrank: https://www.hackerrank.com/interview/interview-preparation-kit
   * AdventOfCode: 24 Challenges to be done before Christmas (or after!): https://adventofcode.com/
   * Solo Learn, mobile app to learn on-the-go: https://www.sololearn.com
 


### PR DESCRIPTION
The page was probably moved. The only interview preparation tutorial I found on Hackerrank is https://www.hackerrank.com/interview/interview-preparation-kit, so I changed a link to a new one. Sorry if this help's unwanted :-)